### PR TITLE
Add timeout for redis connection [ch7262]

### DIFF
--- a/bin/check-sidekiq-latency.rb
+++ b/bin/check-sidekiq-latency.rb
@@ -59,7 +59,7 @@ class SidekiqLatencyCheck < Sensu::Plugin::Check::CLI
    def run
      begin
        Sidekiq.configure_client do |sidekiq_config|
-        sidekiq_config.redis = { url: config[:url] }
+        sidekiq_config.redis = { url: config[:url], timeout: 20 }
        end
 
        latency = Sidekiq::Queue.new(config[:queue]).latency.to_i


### PR DESCRIPTION
CH: https://app.clubhouse.io/chartmogul/story/7262/set-timeout-for-sidekiq-latency-check-sensu-plug-in

I'm adding this timeout on an attempt to silence these warnings:

![image](https://user-images.githubusercontent.com/450960/47999431-dedcda00-e102-11e8-9c0e-21d4cc433216.png)
