### PR TITLE
Fix Redis URL argument usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.10.6

--- a/bin/check-sidekiq-latency.rb
+++ b/bin/check-sidekiq-latency.rb
@@ -59,7 +59,7 @@ class SidekiqLatencyCheck < Sensu::Plugin::Check::CLI
    def run
      begin
        Sidekiq.configure_client do |sidekiq_config|
-        sidekiq_config.redis = { url: config[:url], timeout: 20 }
+        sidekiq_config.redis = { url: config[:redis_url], timeout: 20 } # timeout in seconds
        end
 
        latency = Sidekiq::Queue.new(config[:queue]).latency.to_i
@@ -73,7 +73,7 @@ class SidekiqLatencyCheck < Sensu::Plugin::Check::CLI
        ok "Maximum latency for Sidekiq queue '#{config[:queue]}' is less than #{config[:warn]} seconds"
 
      rescue => error
-        unknown "Could not load Sidekiq stats from #{config[:url]}. Error: #{error}"
+        unknown "Could not load Sidekiq stats from #{config[:redis_url]}. Error: #{error}"
      end
    end
 end

--- a/lib/sensu-plugin-sidekiq-latency/version.rb
+++ b/lib/sensu-plugin-sidekiq-latency/version.rb
@@ -1,3 +1,3 @@
 module SensuPluginSidekiqLatency
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
The plug-in is referencing the Redis URL argument using `config[:url]`, but the correct would be `config[:redis_url]`, as it is defined on line 33.

I've also removed the `.travis.yml` file as it doesn't really do much.