### PR TITLE
Increase Redis timeout and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Checks the latency for a particular sidekiq queue, and warns if it exceeds thres
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bundle install --path vendor/bundle` to install dependencies. Then, run `bundle exec rake spec` to run the "tests".
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `lib/version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/bin/check-sidekiq-latency.rb
+++ b/bin/check-sidekiq-latency.rb
@@ -59,7 +59,7 @@ class SidekiqLatencyCheck < Sensu::Plugin::Check::CLI
    def run
      begin
        Sidekiq.configure_client do |sidekiq_config|
-        sidekiq_config.redis = { url: config[:redis_url], timeout: 20 } # timeout in seconds
+        sidekiq_config.redis = { url: config[:redis_url], timeout: 60 } # timeout in seconds
        end
 
        latency = Sidekiq::Queue.new(config[:queue]).latency.to_i

--- a/lib/sensu-plugin-sidekiq-latency/version.rb
+++ b/lib/sensu-plugin-sidekiq-latency/version.rb
@@ -1,3 +1,3 @@
 module SensuPluginSidekiqLatency
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/sensu-plugins-sidekiq-latency.gemspec
+++ b/sensu-plugins-sidekiq-latency.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sensu-plugin', '~> 1.2'
   spec.add_dependency 'sidekiq', '>= 3.5'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 end

--- a/spec/sensu_plugin_sidekiq_latency_spec.rb
+++ b/spec/sensu_plugin_sidekiq_latency_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe SensuPluginSidekiqLatency do
   it 'has a version number' do
-    expect(Sensu::Plugin::Sidekiq::Latency::VERSION).not_to be nil
+    expect(SensuPluginSidekiqLatency::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'sensu/plugin/sidekiq/latency'
+require 'latency'


### PR DESCRIPTION
Here I increase the timeout to one minute (yeah, I agree it would be better to make it adjustable in the command line, but let's leave that for another time). The README is also updated with more accurate instructions for installing dependencies and "running the tests".